### PR TITLE
Make the babel plugin a devdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
-    "babel-plugin-add-module-exports": "^0.2.1"
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.24.1"
   },
   "babel": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-plugin-add-module-exports": "^0.2.1"
     "babel-preset-es2015": "^6.24.1"
   },
   "babel": {
@@ -23,8 +24,5 @@
     "plugins": [
       "babel-plugin-add-module-exports"
     ]
-  },
-  "dependencies": {
-    "babel-plugin-add-module-exports": "^0.2.1"
   }
 }


### PR DESCRIPTION
This is so that it's not installed in dependents node_modules folders.