### PR TITLE
Add types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,51 @@
+declare module "fftjs" {
+  /**
+   * ## ComplexSpectrum
+   *
+   * A structure to represent a complex spectrum, with real and imaginary
+   * components. For more information on what this structure is used to
+   * represent, see
+   * [here](https://en.wikipedia.org/wiki/Fourier_transform#Complex_domain).
+   */
+  export type ComplexSpectrum = {
+    real: number[];
+    imag: number[];
+  };
+  /**
+   * ## fft
+   *
+   * For a given time domain signal, returns the frequency domain
+   * representation.
+   *
+   * @param signal an audio signal
+   *
+   * @returns a complex spectrum representing the frequency domain of the input
+   * signal
+   *
+   * @example
+   * ```
+   * const signal = [1, 2, 3, 4, 5, 6, 7, 8];
+   * let { real, imag } = fft(signal);
+   * ```
+   */
+  export function fft(signal: ArrayLike<number>): ComplexSpectrum;
+  /**
+   * ## ifft
+   *
+   * For a given frequency domain signal, returns the time domain
+   * representation.
+   *
+   * @param signal a complex spectrum containing the frequency domain
+   * representation of a signal.
+   *
+   * @returns the time domain signal for the given complex spectrum
+   *
+   * @example
+   * ```
+   * const inReal = [1, 2, 3, 4, 5, 6, 7, 8];
+   * const outReal = [1, 2, 3, 4, 5, 6, 7, 8];
+   * let { real, imag } = fft({ real: inReal, imag: outReal });
+   * ```
+   */
+  export function ifft(signal: ComplexSpectrum): ComplexSpectrum;
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "babel src -d dist"
   },
+  "types": "index.d.ts",
   "author": "Nevo Segal",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This PR adds types and typedocs for the library. It doesn't convert the library to typescript though!

Questions:
- [ ] I didn't see anything in the code that would limit the buffer size to a power of two, is that because this implementation handles buffers of arbitrary sizes, or will it fail in a way I don't see?
- [ ] If fftjs handles input buffers of arbitrary sizes, are the output buffers always guaranteed to be the same size, or does it achieve this flexibility by zero padding in some magic way that isn't immediately apparent?
- [ ] ifft returns a complex signal. Is the ordinary time domain signal in the real component or the imaginary component of that complex signal? Or is it more complicated than that? It would be good for me to get it right in the documentation here, rather than gloss over it - but if it's super complicated, I'm happy to leave as is.